### PR TITLE
Fix incorrect shifted result calculation for negative resultShift in YouthguardCalculator

### DIFF
--- a/src/YouthguardCalculator.php
+++ b/src/YouthguardCalculator.php
@@ -42,9 +42,7 @@ class YouthguardCalculator extends Support\Calculator
 		$conversionFactor = $constants['conversionFactor'];
 		$exponent = $constants['exponent'];
 
-		$shiftedResult = $result - $resultShift;
-		if ($resultShift < 0)
-			$shiftedResult = -($result + $resultShift);
+		$shiftedResult = $result + $resultShift;
 
 		if ($shiftedResult < 0)
 			return 0;


### PR DESCRIPTION
This PR fixes the same bug that exists in CombinedCalculator - YouthguardCalculator::calculatePoints() has identical incorrect logic for handling negative resultShift values.

**The Bug:**
```php
$shiftedResult = $result - $resultShift;
if ($resultShift < 0)
    $shiftedResult = -($result + $resultShift);
```

**The Fix:**
```php
$shiftedResult = $result + $resultShift;
```

This matches the correct implementation in IaafCalculator. The formula should simply add the resultShift to the result, not subtract it. The additional conditional that negates the result when resultShift is negative is also incorrect and should be removed.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.