### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ["8.0", "8.1", "8.2", "8.3", "8.4"]
+        php: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3](https://github.com/GlaivePro/IaafPoints/releases/tag/1.2.3)
+### Added
+- PHP 8.5 support.
+
 ## [1.2.2](https://github.com/GlaivePro/IaafPoints/releases/tag/1.2.2)
 ### Added
 - PHP 8.4 support.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0 <8.5"
+        "php": ">=8.0 <8.6"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.0 <11.0"


### PR DESCRIPTION
## Summary
- Widen PHP version constraint from `>=8.0 <8.5` to `>=8.0 <8.6`

## Test results
- **PHP 8.4.21**: 205 tests, 1464 assertions — all passing
- **PHP 8.5.5**: 205 tests, 1464 assertions — all passing (5 deprecation notices, 0 failures)